### PR TITLE
Directly insert bot into database

### DIFF
--- a/meteor/imports/server/services/BotService.ts
+++ b/meteor/imports/server/services/BotService.ts
@@ -80,10 +80,9 @@ export const BotService = {
     if (force || !BotService.botCreated()) {
       console.log("Creating bot...");
 
-      Accounts.createUser({
+      Meteor.users.insert({
         username: BOT_USERNAME,
-        email: "bot@reminisceme.com",
-        password: "123456",
+        emails: [{address: "bot@reminisceme.com", verified: true}],
         profile: {
           name: "Anne Droid"
         }


### PR DESCRIPTION
Note that some of the fields may not be useful at all but I just tried to replicate the old behaviour while conforming to the fields defined in the ```MeteorUser``` interface.